### PR TITLE
Fix for issue/15

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "src/backbone.associate.js",
   "scripts": {
     "pretest": "jshint",
-    "test": "istanbul cover jasmine-node ./spec",
+    "test": "istanbul cover node_modules/jasmine-node/bin/jasmine-node ./spec",
     "posttest": "cat coverage/lcov.info | coveralls"
   },
   "optionalDependencies": {

--- a/spec/backbone.associate.spec.js
+++ b/spec/backbone.associate.spec.js
@@ -365,6 +365,71 @@
         expect(_.result(model.two(), 'url')).toEqual('/klasses');
       });
     });
+    
+    describe('(#15) parent, child, sibling associations', function () {
+
+      var SuperModel, Child, klass1, klass2;
+    
+      beforeEach(function () {
+    
+        SuperModel = Backbone.Model.extend();
+    
+        klass1 = Backbone.Collection.extend({});
+        klass2 = Backbone.Collection.extend({});
+    
+        Backbone.associate(SuperModel, {
+          other: { type: klass1 }
+        });
+    
+        Child = SuperModel.extend();
+    
+        Backbone.associate(Child, {
+          another: { type: klass2 }
+        });
+      });
+    
+      it('leaves original child associations intact', function () {
+        var m = new Child();
+        expect(m.get('another') instanceof klass2).toEqual(true);
+      });
+    
+      it('includes parent association in child association list', function () {
+        var m = new Child();
+        expect(m.get('other') instanceof klass1).toEqual(true);
+      });
+    
+      describe('when a sibling is defined', function () {
+    
+        var ChildSibling;
+    
+        beforeEach(function () {
+    
+          ChildSibling = SuperModel.extend();
+    
+          Backbone.associate(ChildSibling, {
+            another: { type: klass1 }
+          });
+        });
+    
+        it('leaves original child associations intact', function () {
+          var m = new Child();
+          expect(m.get('another') instanceof klass2).toEqual(true);
+        });
+    
+        it('allows new child associations in sibling', function () {
+          var m = new ChildSibling();
+          expect(m.get('another') instanceof klass1).toEqual(true);
+        });
+    
+        it('includes parent association in both sibling\'s association list', function () {
+          var m = new Child();
+          var n = new ChildSibling();
+          expect(m.get('other') instanceof klass1).toEqual(true);
+          expect(n.get('other') instanceof klass1).toEqual(true);
+        });
+      });
+    });
+    
   });
 })();
 

--- a/src/backbone.associate.js
+++ b/src/backbone.associate.js
@@ -175,7 +175,7 @@
   Backbone.dissociate = function (klass) {
     var proto = klass.prototype;
     proto.initialize.unwrap();
-    proto._associations = null;
+    delete proto._associations;
   };
 
   return Backbone;

--- a/src/backbone.associate.js
+++ b/src/backbone.associate.js
@@ -161,10 +161,7 @@
       var inherited_associations = proto._associations;
 
       // Add namespace for associations, adding in any inherited associations
-      proto._associations = {};
-      if (inherited_associations) {
-        _.extend(proto._associations, inherited_associations);
-      }
+      proto._associations = _.extend({}, proto._associations, inherited_associations);
     }
 
     // Now 

--- a/src/backbone.associate.js
+++ b/src/backbone.associate.js
@@ -153,14 +153,21 @@
 
     var proto = klass.prototype;
 
-    if (!proto._associations) {
+    if (!proto.hasOwnProperty('_associations')) {
       // Patch initialize method in prototype
       _wrapMethod(proto, _initialize, 'initialize');
+      
+      // If an _associations namespace exists in the prototype chain, get it
+      var inherited_associations = proto._associations;
 
-      // Add namespace for associations
+      // Add namespace for associations, adding in any inherited associations
       proto._associations = {};
+      if (inherited_associations) {
+        _.extend(proto._associations, inherited_associations);
+      }
     }
 
+    // Now 
     _.extend(proto._associations, associations);
   };
 


### PR DESCRIPTION
This fix checks to see if the _associations namespace available in the prototype chain is actually from the current prototype in the chain before it creates a new one. If the _associations is available but not from the current prototype, it creates a new namespace on the current prototype and extends the one available on the chain onto it. This keeps sibling sub-classes free from stepping on each others toes in when extending using TypeScript.

Note that this request also contains a change to the package.json's "test" script to let the tests run in Windows.